### PR TITLE
Fix the problem of repeated definition of functions

### DIFF
--- a/Source/UnrealMCPBridge/Private/Commands/StateTree/StateTreeCreateOps.cpp
+++ b/Source/UnrealMCPBridge/Private/Commands/StateTree/StateTreeCreateOps.cpp
@@ -187,185 +187,6 @@ static TSharedPtr<FJsonObject> NodeToJsonResult(const FStateTreeEditorNode& Node
 }
 
 /**
- * Resolve a UStateTreeSchema subclass by short name or full path.
- */
-static UClass* ResolveSchemaClass(const FString& SchemaName, FString& OutError)
-{
-	if (SchemaName.IsEmpty())
-	{
-		OutError = TEXT("Empty schema_class");
-		return nullptr;
-	}
-
-	// Try full path
-	UClass* Found = FindObject<UClass>(nullptr, *SchemaName);
-	if (Found && Found->IsChildOf(UStateTreeSchema::StaticClass()))
-	{
-		return Found;
-	}
-
-	// Search by short name
-	TArray<UClass*> Derived;
-	GetDerivedClasses(UStateTreeSchema::StaticClass(), Derived, true);
-	for (UClass* C : Derived)
-	{
-		if (!C || C->HasAnyClassFlags(CLASS_Abstract))
-		{
-			continue;
-		}
-
-		const FString Name = C->GetName();
-		if (Name == SchemaName ||
-			Name == (TEXT("U") + SchemaName) ||
-			(SchemaName.StartsWith(TEXT("U")) && Name == SchemaName.RightChop(1)))
-		{
-			return C;
-		}
-	}
-
-	OutError = FString::Printf(TEXT("Schema class not found: '%s'"), *SchemaName);
-	return nullptr;
-}
-
-/**
- * Parse an EStateTreeStateType from a string.
- */
-static bool ParseStateType(const FString& Str, EStateTreeStateType& OutType)
-{
-	if (Str.IsEmpty() || Str.Equals(TEXT("State"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::State;
-		return true;
-	}
-	if (Str.Equals(TEXT("Group"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::Group;
-		return true;
-	}
-	if (Str.Equals(TEXT("Linked"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::Linked;
-		return true;
-	}
-	if (Str.Equals(TEXT("LinkedAsset"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::LinkedAsset;
-		return true;
-	}
-	if (Str.Equals(TEXT("Subtree"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::Subtree;
-		return true;
-	}
-	return false;
-}
-
-/**
- * Parse an EStateTreeStateSelectionBehavior from a string.
- */
-static bool ParseSelectionBehavior(const FString& Str, EStateTreeStateSelectionBehavior& OutBehavior)
-{
-	if (Str.Equals(TEXT("None"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::None;
-		return true;
-	}
-	if (Str.Equals(TEXT("TryEnterState"), ESearchCase::IgnoreCase) ||
-		Str.Equals(TEXT("TryEnter"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TryEnterState;
-		return true;
-	}
-	if (Str.Equals(TEXT("TrySelectChildrenInOrder"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenInOrder;
-		return true;
-	}
-	if (Str.Equals(TEXT("TrySelectChildrenAtRandom"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenAtRandom;
-		return true;
-	}
-	if (Str.Equals(TEXT("TrySelectChildrenWithHighestUtility"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenWithHighestUtility;
-		return true;
-	}
-	if (Str.Equals(TEXT("TrySelectChildrenAtRandomWeightedByUtility"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenAtRandomWeightedByUtility;
-		return true;
-	}
-	return false;
-}
-
-/**
- * Parse an EStateTreeTransitionTrigger from a string.
- */
-static bool ParseTransitionTrigger(const FString& Str, EStateTreeTransitionTrigger& OutTrigger)
-{
-	if (Str.Equals(TEXT("OnStateCompleted"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnStateCompleted;
-		return true;
-	}
-	if (Str.Equals(TEXT("OnStateSucceeded"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnStateSucceeded;
-		return true;
-	}
-	if (Str.Equals(TEXT("OnStateFailed"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnStateFailed;
-		return true;
-	}
-	if (Str.Equals(TEXT("OnTick"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnTick;
-		return true;
-	}
-	if (Str.Equals(TEXT("OnEvent"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnEvent;
-		return true;
-	}
-	return false;
-}
-
-/**
- * Parse an EStateTreeTransitionPriority from a string.
- */
-static bool ParseTransitionPriority(const FString& Str, EStateTreeTransitionPriority& OutPriority)
-{
-	if (Str.IsEmpty() || Str.Equals(TEXT("Normal"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::Normal;
-		return true;
-	}
-	if (Str.Equals(TEXT("Low"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::Low;
-		return true;
-	}
-	if (Str.Equals(TEXT("Medium"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::Medium;
-		return true;
-	}
-	if (Str.Equals(TEXT("High"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::High;
-		return true;
-	}
-	if (Str.Equals(TEXT("Critical"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::Critical;
-		return true;
-	}
-	return false;
-}
-
-/**
  * Parse an EPropertyBagPropertyType from a user-facing type string.
  * Returns None on unknown types. Also outputs a UScriptStruct* for struct types.
  */
@@ -491,7 +312,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleCreateStateTree(
 
 	// Resolve schema class
 	FString SchemaError;
-	UClass* SchemaClass = ResolveSchemaClass(SchemaClassName, SchemaError);
+	UClass* SchemaClass = StateTreeHelpers::ResolveSchemaClass(SchemaClassName, SchemaError);
 	if (!SchemaClass)
 	{
 		return FEpicUnrealMCPCommonUtils::CreateErrorResponse(SchemaError);
@@ -571,7 +392,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleAddStateTreeState
 	FString StateTypeStr;
 	Params->TryGetStringField(TEXT("state_type"), StateTypeStr);
 	EStateTreeStateType StateType = EStateTreeStateType::State;
-	if (!StateTypeStr.IsEmpty() && !ParseStateType(StateTypeStr, StateType))
+	if (!StateTypeStr.IsEmpty() && !StateTreeHelpers::ParseStateType(StateTypeStr, StateType))
 	{
 		return FEpicUnrealMCPCommonUtils::CreateErrorResponse(
 			FString::Printf(TEXT("Invalid state_type: '%s'"), *StateTypeStr));
@@ -643,7 +464,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleAddStateTreeState
 	if (Params->TryGetStringField(TEXT("selection_behavior"), SelectionStr))
 	{
 		EStateTreeStateSelectionBehavior Behavior;
-		if (ParseSelectionBehavior(SelectionStr, Behavior))
+		if (StateTreeHelpers::ParseSelectionBehavior(SelectionStr, Behavior))
 		{
 			NewState->SelectionBehavior = Behavior;
 		}
@@ -1058,7 +879,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleAddStateTreeTrans
 
 	// Parse trigger
 	EStateTreeTransitionTrigger Trigger;
-	if (!ParseTransitionTrigger(TriggerStr, Trigger))
+	if (!StateTreeHelpers::ParseTransitionTrigger(TriggerStr, Trigger))
 	{
 		return FEpicUnrealMCPCommonUtils::CreateErrorResponse(
 			FString::Printf(TEXT("Invalid trigger: '%s'"), *TriggerStr));
@@ -1068,7 +889,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleAddStateTreeTrans
 	FString PriorityStr;
 	Params->TryGetStringField(TEXT("priority"), PriorityStr);
 	EStateTreeTransitionPriority Priority = EStateTreeTransitionPriority::Normal;
-	if (!PriorityStr.IsEmpty() && !ParseTransitionPriority(PriorityStr, Priority))
+	if (!PriorityStr.IsEmpty() && !StateTreeHelpers::ParseTransitionPriority(PriorityStr, Priority))
 	{
 		return FEpicUnrealMCPCommonUtils::CreateErrorResponse(
 			FString::Printf(TEXT("Invalid priority: '%s'"), *PriorityStr));

--- a/Source/UnrealMCPBridge/Private/Commands/StateTree/StateTreeHelpers.cpp
+++ b/Source/UnrealMCPBridge/Private/Commands/StateTree/StateTreeHelpers.cpp
@@ -6,6 +6,7 @@
 #include "StateTreeState.h"
 #include "StateTreeEditorNode.h"
 #include "StateTreeTypes.h"
+#include "StateTreeSchema.h"
 #include "StateTreeCompiler.h"
 #include "StateTreeCompilerLog.h"
 #include "StateTreePropertyBindings.h"
@@ -16,6 +17,7 @@
 #include "StructUtils/PropertyBag.h"
 
 #include "Logging/TokenizedMessage.h"
+#include "UObject/UObjectIterator.h"
 #include "UObject/UnrealType.h"
 
 // ---------------------------------------------------------------------------
@@ -1041,6 +1043,179 @@ FString StateTreeHelpers::TaskCompletionTypeToString(uint8 CompletionType)
 	default:
 		return TEXT("Unknown");
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Enum Parsing / Class Resolution
+// ---------------------------------------------------------------------------
+
+UClass* StateTreeHelpers::ResolveSchemaClass(const FString& SchemaName, FString& OutError)
+{
+	if (SchemaName.IsEmpty())
+	{
+		OutError = TEXT("Empty schema_class");
+		return nullptr;
+	}
+
+	// First, resolve according to the complete object path, and support the caller to directly pass in the exact class path.
+	UClass* Found = FindObject<UClass>(nullptr, *SchemaName);
+	if (Found && Found->IsChildOf(UStateTreeSchema::StaticClass()))
+	{
+		return Found;
+	}
+
+	// Then traverse the derived class by short name, compatible with two writing methods with and without U prefix.
+	TArray<UClass*> Derived;
+	GetDerivedClasses(UStateTreeSchema::StaticClass(), Derived, true);
+	for (UClass* C : Derived)
+	{
+		if (!C || C->HasAnyClassFlags(CLASS_Abstract))
+		{
+			continue;
+		}
+
+		const FString Name = C->GetName();
+		if (Name == SchemaName ||
+			Name == (TEXT("U") + SchemaName) ||
+			(SchemaName.StartsWith(TEXT("U")) && Name == SchemaName.RightChop(1)))
+		{
+			return C;
+		}
+	}
+
+	OutError = FString::Printf(TEXT("Schema class not found: '%s'"), *SchemaName);
+	return nullptr;
+}
+
+bool StateTreeHelpers::ParseStateType(const FString& Str, EStateTreeStateType& OutType)
+{
+	if (Str.IsEmpty() || Str.Equals(TEXT("State"), ESearchCase::IgnoreCase))
+	{
+		OutType = EStateTreeStateType::State;
+		return true;
+	}
+	if (Str.Equals(TEXT("Group"), ESearchCase::IgnoreCase))
+	{
+		OutType = EStateTreeStateType::Group;
+		return true;
+	}
+	if (Str.Equals(TEXT("Linked"), ESearchCase::IgnoreCase))
+	{
+		OutType = EStateTreeStateType::Linked;
+		return true;
+	}
+	if (Str.Equals(TEXT("LinkedAsset"), ESearchCase::IgnoreCase))
+	{
+		OutType = EStateTreeStateType::LinkedAsset;
+		return true;
+	}
+	if (Str.Equals(TEXT("Subtree"), ESearchCase::IgnoreCase))
+	{
+		OutType = EStateTreeStateType::Subtree;
+		return true;
+	}
+	return false;
+}
+
+bool StateTreeHelpers::ParseSelectionBehavior(const FString& Str, EStateTreeStateSelectionBehavior& OutBehavior)
+{
+	if (Str.Equals(TEXT("None"), ESearchCase::IgnoreCase))
+	{
+		OutBehavior = EStateTreeStateSelectionBehavior::None;
+		return true;
+	}
+	if (Str.Equals(TEXT("TryEnterState"), ESearchCase::IgnoreCase) ||
+		Str.Equals(TEXT("TryEnter"), ESearchCase::IgnoreCase))
+	{
+		OutBehavior = EStateTreeStateSelectionBehavior::TryEnterState;
+		return true;
+	}
+	if (Str.Equals(TEXT("TrySelectChildrenInOrder"), ESearchCase::IgnoreCase))
+	{
+		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenInOrder;
+		return true;
+	}
+	if (Str.Equals(TEXT("TrySelectChildrenAtRandom"), ESearchCase::IgnoreCase))
+	{
+		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenAtRandom;
+		return true;
+	}
+	if (Str.Equals(TEXT("TrySelectChildrenWithHighestUtility"), ESearchCase::IgnoreCase))
+	{
+		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenWithHighestUtility;
+		return true;
+	}
+	if (Str.Equals(TEXT("TrySelectChildrenAtRandomWeightedByUtility"), ESearchCase::IgnoreCase))
+	{
+		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenAtRandomWeightedByUtility;
+		return true;
+	}
+	if (Str.Equals(TEXT("TryFollowTransitions"), ESearchCase::IgnoreCase))
+	{
+		OutBehavior = EStateTreeStateSelectionBehavior::TryFollowTransitions;
+		return true;
+	}
+	return false;
+}
+
+bool StateTreeHelpers::ParseTransitionTrigger(const FString& Str, EStateTreeTransitionTrigger& OutTrigger)
+{
+	if (Str.Equals(TEXT("OnStateCompleted"), ESearchCase::IgnoreCase))
+	{
+		OutTrigger = EStateTreeTransitionTrigger::OnStateCompleted;
+		return true;
+	}
+	if (Str.Equals(TEXT("OnStateSucceeded"), ESearchCase::IgnoreCase))
+	{
+		OutTrigger = EStateTreeTransitionTrigger::OnStateSucceeded;
+		return true;
+	}
+	if (Str.Equals(TEXT("OnStateFailed"), ESearchCase::IgnoreCase))
+	{
+		OutTrigger = EStateTreeTransitionTrigger::OnStateFailed;
+		return true;
+	}
+	if (Str.Equals(TEXT("OnTick"), ESearchCase::IgnoreCase))
+	{
+		OutTrigger = EStateTreeTransitionTrigger::OnTick;
+		return true;
+	}
+	if (Str.Equals(TEXT("OnEvent"), ESearchCase::IgnoreCase))
+	{
+		OutTrigger = EStateTreeTransitionTrigger::OnEvent;
+		return true;
+	}
+	return false;
+}
+
+bool StateTreeHelpers::ParseTransitionPriority(const FString& Str, EStateTreeTransitionPriority& OutPriority)
+{
+	if (Str.IsEmpty() || Str.Equals(TEXT("Normal"), ESearchCase::IgnoreCase))
+	{
+		OutPriority = EStateTreeTransitionPriority::Normal;
+		return true;
+	}
+	if (Str.Equals(TEXT("Low"), ESearchCase::IgnoreCase))
+	{
+		OutPriority = EStateTreeTransitionPriority::Low;
+		return true;
+	}
+	if (Str.Equals(TEXT("Medium"), ESearchCase::IgnoreCase))
+	{
+		OutPriority = EStateTreeTransitionPriority::Medium;
+		return true;
+	}
+	if (Str.Equals(TEXT("High"), ESearchCase::IgnoreCase))
+	{
+		OutPriority = EStateTreeTransitionPriority::High;
+		return true;
+	}
+	if (Str.Equals(TEXT("Critical"), ESearchCase::IgnoreCase))
+	{
+		OutPriority = EStateTreeTransitionPriority::Critical;
+		return true;
+	}
+	return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/Source/UnrealMCPBridge/Private/Commands/StateTree/StateTreeHelpers.h
+++ b/Source/UnrealMCPBridge/Private/Commands/StateTree/StateTreeHelpers.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Json.h"
+#include "StateTreeTypes.h"
 #include "StructUtils/InstancedStruct.h"
 
 class UStateTree;
@@ -138,6 +139,23 @@ namespace StateTreeHelpers
 	FString TransitionPriorityToString(uint8 Priority);
 	FString ExpressionOperandToString(uint8 Operand);
 	FString TaskCompletionTypeToString(uint8 CompletionType);
+
+	// ---- Enum Parsing / Class Resolution ----
+
+	/** Parses an MCP input string to a StateTree state type. */
+	bool ParseStateType(const FString& Str, EStateTreeStateType& OutType);
+
+	/** Parses MCP input string into a StateTree child state selection behavior. */
+	bool ParseSelectionBehavior(const FString& Str, EStateTreeStateSelectionBehavior& OutBehavior);
+
+	/** Parses MCP input string into a StateTree transition trigger type. */
+	bool ParseTransitionTrigger(const FString& Str, EStateTreeTransitionTrigger& OutTrigger);
+
+	/** Parses MCP input string into a StateTree transition priority. */
+	bool ParseTransitionPriority(const FString& Str, EStateTreeTransitionPriority& OutPriority);
+
+	/** Resolves a UStateTreeSchema subclass by short name or full path. */
+	UClass* ResolveSchemaClass(const FString& SchemaName, FString& OutError);
 
 	// ---- Compilation ----
 

--- a/Source/UnrealMCPBridge/Private/Commands/StateTree/StateTreeModifyOps.cpp
+++ b/Source/UnrealMCPBridge/Private/Commands/StateTree/StateTreeModifyOps.cpp
@@ -15,182 +15,6 @@
 
 using PU = FEpicUnrealMCPPropertyUtils;
 
-// ---------------------------------------------------------------------------
-// Local enum parsers (duplicated from CreateOps because they are file-static)
-// ---------------------------------------------------------------------------
-
-static bool ParseStateType(const FString& Str, EStateTreeStateType& OutType)
-{
-	if (Str.IsEmpty() || Str.Equals(TEXT("State"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::State;
-		return true;
-	}
-	if (Str.Equals(TEXT("Group"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::Group;
-		return true;
-	}
-	if (Str.Equals(TEXT("Linked"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::Linked;
-		return true;
-	}
-	if (Str.Equals(TEXT("LinkedAsset"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::LinkedAsset;
-		return true;
-	}
-	if (Str.Equals(TEXT("Subtree"), ESearchCase::IgnoreCase))
-	{
-		OutType = EStateTreeStateType::Subtree;
-		return true;
-	}
-	return false;
-}
-
-static bool ParseSelectionBehavior(const FString& Str, EStateTreeStateSelectionBehavior& OutBehavior)
-{
-	if (Str.Equals(TEXT("None"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::None;
-		return true;
-	}
-	if (Str.Equals(TEXT("TryEnterState"), ESearchCase::IgnoreCase) ||
-		Str.Equals(TEXT("TryEnter"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TryEnterState;
-		return true;
-	}
-	if (Str.Equals(TEXT("TrySelectChildrenInOrder"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenInOrder;
-		return true;
-	}
-	if (Str.Equals(TEXT("TrySelectChildrenAtRandom"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenAtRandom;
-		return true;
-	}
-	if (Str.Equals(TEXT("TrySelectChildrenWithHighestUtility"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenWithHighestUtility;
-		return true;
-	}
-	if (Str.Equals(TEXT("TrySelectChildrenAtRandomWeightedByUtility"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TrySelectChildrenAtRandomWeightedByUtility;
-		return true;
-	}
-	if (Str.Equals(TEXT("TryFollowTransitions"), ESearchCase::IgnoreCase))
-	{
-		OutBehavior = EStateTreeStateSelectionBehavior::TryFollowTransitions;
-		return true;
-	}
-	return false;
-}
-
-static bool ParseTransitionTrigger(const FString& Str, EStateTreeTransitionTrigger& OutTrigger)
-{
-	if (Str.Equals(TEXT("OnStateCompleted"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnStateCompleted;
-		return true;
-	}
-	if (Str.Equals(TEXT("OnStateSucceeded"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnStateSucceeded;
-		return true;
-	}
-	if (Str.Equals(TEXT("OnStateFailed"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnStateFailed;
-		return true;
-	}
-	if (Str.Equals(TEXT("OnTick"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnTick;
-		return true;
-	}
-	if (Str.Equals(TEXT("OnEvent"), ESearchCase::IgnoreCase))
-	{
-		OutTrigger = EStateTreeTransitionTrigger::OnEvent;
-		return true;
-	}
-	return false;
-}
-
-static bool ParseTransitionPriority(const FString& Str, EStateTreeTransitionPriority& OutPriority)
-{
-	if (Str.IsEmpty() || Str.Equals(TEXT("Normal"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::Normal;
-		return true;
-	}
-	if (Str.Equals(TEXT("Low"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::Low;
-		return true;
-	}
-	if (Str.Equals(TEXT("Medium"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::Medium;
-		return true;
-	}
-	if (Str.Equals(TEXT("High"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::High;
-		return true;
-	}
-	if (Str.Equals(TEXT("Critical"), ESearchCase::IgnoreCase))
-	{
-		OutPriority = EStateTreeTransitionPriority::Critical;
-		return true;
-	}
-	return false;
-}
-
-/**
- * Resolve a UStateTreeSchema subclass by short name or full path.
- */
-static UClass* ResolveSchemaClass(const FString& SchemaName, FString& OutError)
-{
-	if (SchemaName.IsEmpty())
-	{
-		OutError = TEXT("Empty schema_class");
-		return nullptr;
-	}
-
-	// Try full path first
-	UClass* Found = FindObject<UClass>(nullptr, *SchemaName);
-	if (Found && Found->IsChildOf(UStateTreeSchema::StaticClass()))
-	{
-		return Found;
-	}
-
-	// Search by short name across all derived classes
-	TArray<UClass*> Derived;
-	GetDerivedClasses(UStateTreeSchema::StaticClass(), Derived, true);
-	for (UClass* C : Derived)
-	{
-		if (!C || C->HasAnyClassFlags(CLASS_Abstract))
-		{
-			continue;
-		}
-
-		const FString Name = C->GetName();
-		if (Name == SchemaName ||
-			Name == (TEXT("U") + SchemaName) ||
-			(SchemaName.StartsWith(TEXT("U")) && Name == SchemaName.RightChop(1)))
-		{
-			return C;
-		}
-	}
-
-	OutError = FString::Printf(TEXT("Schema class not found: '%s'"), *SchemaName);
-	return nullptr;
-}
-
 /**
  * Convert a JSON value to a plain string suitable for ImportText_Direct.
  */
@@ -355,7 +179,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleSetStateTreeState
 	else if (PropertyName.Equals(TEXT("Type"), ESearchCase::IgnoreCase))
 	{
 		EStateTreeStateType NewType;
-		if (!ParseStateType(ValueStr, NewType))
+		if (!StateTreeHelpers::ParseStateType(ValueStr, NewType))
 		{
 			return FEpicUnrealMCPCommonUtils::CreateErrorResponse(
 				FString::Printf(TEXT("Invalid state type: '%s'. Valid: State, Group, Linked, LinkedAsset, Subtree"), *ValueStr));
@@ -365,7 +189,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleSetStateTreeState
 	else if (PropertyName.Equals(TEXT("SelectionBehavior"), ESearchCase::IgnoreCase))
 	{
 		EStateTreeStateSelectionBehavior NewBehavior;
-		if (!ParseSelectionBehavior(ValueStr, NewBehavior))
+		if (!StateTreeHelpers::ParseSelectionBehavior(ValueStr, NewBehavior))
 		{
 			return FEpicUnrealMCPCommonUtils::CreateErrorResponse(
 				FString::Printf(TEXT("Invalid selection behavior: '%s'. Valid: None, TryEnterState, TrySelectChildrenInOrder, TrySelectChildrenAtRandom, TrySelectChildrenWithHighestUtility, TrySelectChildrenAtRandomWeightedByUtility, TryFollowTransitions"), *ValueStr));
@@ -592,7 +416,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleSetStateTreeTrans
 	if (PropertyName.Equals(TEXT("Trigger"), ESearchCase::IgnoreCase))
 	{
 		EStateTreeTransitionTrigger NewTrigger;
-		if (!ParseTransitionTrigger(ValueStr, NewTrigger))
+		if (!StateTreeHelpers::ParseTransitionTrigger(ValueStr, NewTrigger))
 		{
 			return FEpicUnrealMCPCommonUtils::CreateErrorResponse(
 				FString::Printf(TEXT("Invalid trigger: '%s'. Valid: OnStateCompleted, OnStateSucceeded, OnStateFailed, OnTick, OnEvent"), *ValueStr));
@@ -602,7 +426,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleSetStateTreeTrans
 	else if (PropertyName.Equals(TEXT("Priority"), ESearchCase::IgnoreCase))
 	{
 		EStateTreeTransitionPriority NewPriority;
-		if (!ParseTransitionPriority(ValueStr, NewPriority))
+		if (!StateTreeHelpers::ParseTransitionPriority(ValueStr, NewPriority))
 		{
 			return FEpicUnrealMCPCommonUtils::CreateErrorResponse(
 				FString::Printf(TEXT("Invalid priority: '%s'. Valid: Low, Normal, Medium, High, Critical"), *ValueStr));
@@ -759,7 +583,7 @@ TSharedPtr<FJsonObject> FEpicUnrealMCPStateTreeCommands::HandleSetStateTreeSchem
 		return FEpicUnrealMCPCommonUtils::CreateErrorResponse(Error);
 	}
 
-	UClass* SchemaClass = ResolveSchemaClass(SchemaClassName, Error);
+	UClass* SchemaClass = StateTreeHelpers::ResolveSchemaClass(SchemaClassName, Error);
 	if (!SchemaClass)
 	{
 		return FEpicUnrealMCPCommonUtils::CreateErrorResponse(Error);


### PR DESCRIPTION
### Fix C2084 Compilation Errors via Refactoring
Fixed compilation errors caused by duplicate function definitions (C2084).
Refactored the shared StateTree parsing/resolution utility functions into a dedicated StateTreeHelpers class, removing duplicate implementations from StateTreeCreateOps.cpp and StateTreeModifyOps.cpp.
This resolves all related build failures and cleans up redundant code.